### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ From your main activity
 
 The models must extend <b>DNKObject</b> and uses annotations to give knowledge of your schema to the lib.
 
-###Annotations
+### Annotations
 This project uses annotations to know some things about your scheme
 
 	//Defines the recordtype. Must match one on CloudKit dashboard.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
